### PR TITLE
Refresh resume page design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# react-porfolio
+# React Portfolio Resume
+
+A refreshed, single-page resume experience for Evan Gerweck. The page highlights experience, projects, skills, and contact details with a polished glassmorphism-inspired layout.
+
+## Getting started
+
+1. Start a local web server (for example `python -m http.server 8000`).
+2. Visit `http://localhost:8000/resume.html` in your browser to explore the resume page.
+
+## Customisation
+
+Update `resume.html` to change the content and edit `styles/resume.css` to tweak the presentation or theme.

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Evan Gerweck | Resume</title>
+  <link rel="stylesheet" href="styles/resume.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="hero__tag">Product-Focused Full-Stack Engineer</p>
+      <h1 class="hero__title">Evan Gerweck</h1>
+      <p class="hero__subtitle">Building polished digital experiences with delightful user journeys.</p>
+      <div class="hero__meta">
+        <span>Denver, CO</span>
+        <span>•</span>
+        <a href="mailto:gerweckevan@gmail.com">gerweckevan@gmail.com</a>
+        <span>•</span>
+        <a href="https://www.linkedin.com/in/evangerweck" target="_blank" rel="noopener">LinkedIn</a>
+      </div>
+      <div class="hero__actions">
+        <a class="btn" href="#contact">Let's work together</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="card summary">
+      <h2>Summary</h2>
+      <p>
+        Engineer with a product mindset and a passion for storytelling through design.
+        I work across the stack to deliver resilient, performant applications while
+        keeping the user experience front and center.
+      </p>
+    </section>
+
+    <section class="card experience">
+      <h2>Experience</h2>
+      <article class="timeline__item">
+        <header>
+          <h3>Senior Front-End Engineer · Freelance</h3>
+          <span class="timeline__range">2021 — Present</span>
+        </header>
+        <ul>
+          <li>Partner with founders and creative teams to design, prototype, and build marketing experiences for new product launches.</li>
+          <li>Lead accessibility audits and implement improvements that boost Lighthouse scores and inclusive design metrics.</li>
+          <li>Introduce component-driven architecture that cuts build time and improves maintainability across client projects.</li>
+        </ul>
+      </article>
+      <article class="timeline__item">
+        <header>
+          <h3>Product Designer &amp; Engineer · Various Teams</h3>
+          <span class="timeline__range">2017 — 2021</span>
+        </header>
+        <ul>
+          <li>Ran design sprints to align stakeholders, translated insights into polished UI, and shipped features used by thousands of customers.</li>
+          <li>Built internal tooling that automated manual workflows and reduced operational overhead by 35%.</li>
+          <li>Mentored designers and junior engineers on bridging the gap between concept and implementation.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="card projects">
+      <h2>Highlighted Projects</h2>
+      <article>
+        <h3>Storyteller Portfolio</h3>
+        <p>Interactive case-study platform with scroll-driven animations and custom CMS integration for effortless content updates.</p>
+        <ul class="tags">
+          <li>React</li>
+          <li>Three.js</li>
+          <li>Node</li>
+        </ul>
+      </article>
+      <article>
+        <h3>Growth Experimentation Toolkit</h3>
+        <p>Experiment dashboard that aggregates analytics, automates reporting, and helps teams prioritize high-impact experiments.</p>
+        <ul class="tags">
+          <li>Next.js</li>
+          <li>TypeScript</li>
+          <li>PostgreSQL</li>
+        </ul>
+      </article>
+      <article>
+        <h3>DesignOps Playbook</h3>
+        <p>Guided onboarding experience and resource hub for design teams, featuring interactive workshops and component libraries.</p>
+        <ul class="tags">
+          <li>Figma</li>
+          <li>Storybook</li>
+          <li>Design Systems</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="card skills">
+      <h2>Skills</h2>
+      <div class="skills__grid">
+        <div>
+          <h3>Engineering</h3>
+          <ul>
+            <li>React, Next.js, TypeScript</li>
+            <li>Node.js, Express</li>
+            <li>REST &amp; GraphQL APIs</li>
+            <li>Vercel, Netlify, AWS</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Design</h3>
+          <ul>
+            <li>UI/UX Research</li>
+            <li>Design Systems</li>
+            <li>Interaction Design</li>
+            <li>Rapid Prototyping</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Collaboration</h3>
+          <ul>
+            <li>Product Strategy</li>
+            <li>Workshop Facilitation</li>
+            <li>Cross-functional Leadership</li>
+            <li>Stakeholder Alignment</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="card education">
+      <h2>Education</h2>
+      <article>
+        <h3>Colorado State University</h3>
+        <p>B.S. in Computer Information Systems, 2017</p>
+      </article>
+    </section>
+
+    <section class="card contact" id="contact">
+      <h2>Contact</h2>
+      <p>I'm always interested in collaborating on meaningful products and thoughtful brand experiences.</p>
+      <a class="btn btn--outline" href="mailto:gerweckevan@gmail.com">Start a conversation</a>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>© <span id="year"></span> Evan Gerweck. Crafted with intent and curiosity.</p>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/styles/resume.css
+++ b/styles/resume.css
@@ -1,0 +1,278 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --bg-alt: rgba(15, 23, 42, 0.7);
+  --surface: rgba(30, 41, 59, 0.7);
+  --surface-strong: #1f2937;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.1);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: radial-gradient(circle at 20% -20%, rgba(56, 189, 248, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(244, 114, 182, 0.2), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.hero {
+  padding: clamp(3rem, 8vw, 5rem) 1.5rem 3rem;
+  display: flex;
+  justify-content: center;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.3), rgba(129, 140, 248, 0.2));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 12px 48px rgba(15, 23, 42, 0.65);
+}
+
+.hero__content {
+  max-width: 860px;
+  text-align: center;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero__tag {
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.32em;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.hero__title {
+  font-size: clamp(2.75rem, 5vw, 3.5rem);
+  font-weight: 700;
+}
+
+.hero__subtitle {
+  color: var(--muted);
+  max-width: 40rem;
+  margin: 0 auto;
+}
+
+.hero__meta {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero__meta a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.hero__meta a:hover,
+.hero__meta a:focus {
+  color: var(--text);
+}
+
+.hero__actions {
+  display: flex;
+  justify-content: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: var(--accent);
+  border: none;
+  color: #0b1120;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 40px rgba(56, 189, 248, 0.4);
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  box-shadow: none;
+}
+
+.btn--outline:hover,
+.btn--outline:focus {
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+.layout {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: clamp(2rem, 6vw, 4rem) 1.5rem 4rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.card {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.6));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 24px 60px rgba(8, 11, 19, 0.45);
+  backdrop-filter: blur(10px);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.card h2 {
+  font-size: 1.35rem;
+  letter-spacing: -0.02em;
+}
+
+.summary p {
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.timeline__item {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.timeline__item header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.timeline__item h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.timeline__range {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.timeline__item ul {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--muted);
+}
+
+.projects article {
+  padding: 1.25rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.projects h3 {
+  font-size: 1.1rem;
+}
+
+.projects p {
+  color: var(--muted);
+}
+
+.tags {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tags li {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.skills__grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.skills__grid h3 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.skills__grid ul {
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.skills__grid li {
+  color: var(--text);
+}
+
+.education p,
+.contact p {
+  color: var(--muted);
+}
+
+.footer {
+  padding: 2rem 1.5rem 3rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (min-width: 768px) {
+  .layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summary,
+  .contact,
+  .education {
+    grid-column: span 2;
+  }
+
+  .projects {
+    grid-column: span 2;
+  }
+
+  .skills__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `resume.html` page with updated content and contact details
- add `styles/resume.css` to provide a polished glassmorphism-inspired layout
- update the README with instructions for serving and customising the resume

## Testing
- no automated tests (static HTML/CSS site)


------
https://chatgpt.com/codex/tasks/task_e_68dadf195bb8832d93dbcb724ba1dc27